### PR TITLE
fix(917) : Double L0c DS production generates fake alarms

### DIFF
--- a/rs-addons/S2_L0C/Executables/stream-parameters.properties
+++ b/rs-addons/S2_L0C/Executables/stream-parameters.properties
@@ -77,7 +77,7 @@ app.*.spring.cloud.stream.bindings.input.consumer.max-attempts=1
 app.pw-l0c.spring.cloud.stream.bindings.input.group=s2-l0c-pw
 app.ew-l0c.spring.cloud.stream.bindings.input.group=s2-l0c-ew
 
-app.ew-l0c.spring.cloud.stream.kafka.binder.consumer-properties.max.poll.interval.ms=3600000
+app.ew-l0c.spring.cloud.stream.kafka.binder.consumer-properties.max.poll.interval.ms=7200000
 app.ew-l0c.spring.cloud.stream.kafka.binder.consumer-properties.max.poll.records=1
 
 ### Preparation worker


### PR DESCRIPTION
Increase kafka timeout from 1 hour to 2 hours.